### PR TITLE
Extracted text formatter to separate service for consuming it in the components

### DIFF
--- a/src/components/BookingEditor.js
+++ b/src/components/BookingEditor.js
@@ -14,7 +14,17 @@ export default function CfBookingEditor (AbstractEntityModalEditor, {mapState, m
         from: 'bookingHelpers'
       },
 
+      /**
+       * Function for text formatting, it will replace placeholders to given values.
+       *
+       * @var {Function}
+       */
+      'formatter': {
+        from: 'textFormatter'
+      },
+
       'humanizeDuration': 'humanizeDuration',
+
       /**
        * Modal state injected from elsewhere.
        *

--- a/src/components/BookingsListView.js
+++ b/src/components/BookingsListView.js
@@ -3,12 +3,22 @@ export function CfBookingsListView (AbstractBookingsView, { mapState, mapMutatio
     inject: {
       'isMobile': 'isMobile',
       'bookingHelpers': 'bookingHelpers',
+      'config': 'config',
       'list-table': {
         from: 'wpListTable'
       },
       '_': {
         from: 'translate'
       },
+
+      /**
+       * Function for text formatting, it will replace placeholders to given values.
+       *
+       * @var {Function}
+       */
+      'formatter': {
+        from: 'textFormatter'
+      }
     },
 
     data () {

--- a/src/libs/index.js
+++ b/src/libs/index.js
@@ -56,9 +56,12 @@ export default function (dependencies) {
     pluralize: function () {
       return dependencies.pluralize
     },
-    translator: function () {
+    textFormatter: function () {
+      return dependencies.textFormatter.vsprintf
+    },
+    translator: function (container) {
       return new dependencies.uiFramework.I18n.FormatTranslator(
-        dependencies.textFormatter.vsprintf
+        container.textFormatter
       )
     },
     translate: function (container) {


### PR DESCRIPTION
Helps to fix https://github.com/RebelCode/rcmod-wp-bookings-ui/issues/12

---
*Note:* these changes are made on top of the changes made in PR #17, branch `task/transitions-for-status-update`. The target merge branch for this PR has been set accordingly.