### PR TITLE
Fixing DateTime picker behavior

### DIFF
--- a/src/components/DatetimePicker.js
+++ b/src/components/DatetimePicker.js
@@ -42,7 +42,13 @@ export function CfDatetimePicker (DatetimePicker, moment, format) {
        */
       timeValue: {
         get () {
-          if (!this.value || this.timeDisabled) return null
+          if (!this.value || this.timeDisabled) {
+            return {
+              HH: 0,
+              mm: 0,
+              ss: 0
+            }
+          }
 
           const datetime = moment(this.value)
           return {


### PR DESCRIPTION
fixes #48 

### Fix explanation
Added changes allows to always have a time part in datetime picker's value, even when time selecting is disabled (`00:00:00` in this case). This is done in order to achieve consistency between time format (ISO8601) used across application.

As a result, time format is always valid for datetime validator, and it doesn't throw error when time selecting is disabled (due to all day tick).