### PR TITLE
Added disabled property to day and week time units

### DIFF
--- a/src/components/SessionLength.js
+++ b/src/components/SessionLength.js
@@ -21,9 +21,11 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
         }, {
           title: this._('days'),
           seconds: 60 * 60 * 24,
+          disabled: true
         }, {
           title: this._('weeks'),
           seconds: 60 * 60 * 24 * 7,
+          disabled: true
         }],
 
         sessionTimeUnit: 60,


### PR DESCRIPTION
Helps to fix https://github.com/RebelCode/rcmod-wp-bookings-ui/issues/41

### Explanation
I've added `disabled` property for `day` and `week` time units on session length tab for disabling them in ui. If value of `disabled` property equals to `true`, it will be disabled in time units select box on session lengths tab.