### PR TITLE
added limit on value in session length field

### DIFF
--- a/src/components/SessionLength.js
+++ b/src/components/SessionLength.js
@@ -69,7 +69,16 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
         deep: true,
         handler () {
           this.validationError = null
+          this.limitSessionLength()
         }
+      },
+      /**
+       * Watch for `maxSessionLength` change and apply session length limit if needed.
+       *
+       * @since [*next-version*]
+       */
+      maxSessionLength () {
+        this.limitSessionLength()
       }
     },
     computed: {
@@ -77,7 +86,18 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
         storeSessions: state => state.app.sessionLengths.sort((a, b) => {
           return a.sessionLength - b.sessionLength
         })
-      })
+      }),
+      /**
+       * Max possible value of session length (less then day).
+       *
+       * @since [*next-version*]
+       *
+       * @var {number}
+       */
+      maxSessionLength () {
+        const maxSessionLength = 60 * 60 * 24 - 1
+        return Math.floor(maxSessionLength / this.sessionTimeUnit)
+      }
     },
     methods: {
       ...mapMutations([
@@ -89,6 +109,17 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
           units: ['w', 'd', 'h', 'm'],
           round: true
         })
+      },
+
+      /**
+       * Apply session length limit if needed.
+       *
+       * @since [*next-version*]
+       */
+      limitSessionLength () {
+        if (this.sessionDefault.sessionLength > this.maxSessionLength) {
+          this.sessionDefault.sessionLength = this.maxSessionLength
+        }
       },
 
       /**

--- a/src/components/SessionLength.js
+++ b/src/components/SessionLength.js
@@ -60,6 +60,16 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
         })
       }
     },
+    props: {
+      /**
+       * @since [*next-version*]
+       *
+       * @property {number} sessionLengthLimit Session length limit in seconds.
+       */
+      sessionLengthLimit: {
+        type: Number
+      }
+    },
     watch: {
       /**
        * Session default watcher that removes validation error
@@ -95,8 +105,7 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
        * @var {number}
        */
       maxSessionLength () {
-        const maxSessionLength = 60 * 60 * 24 - 1
-        return Math.floor(maxSessionLength / this.sessionTimeUnit)
+        return Math.floor(this.sessionLengthLimit / this.sessionTimeUnit)
       }
     },
     methods: {
@@ -117,6 +126,9 @@ export default function CfSessionLength (Vue, Vuex, FunctionalArrayCollection) {
        * @since [*next-version*]
        */
       limitSessionLength () {
+        if (!this.sessionLengthLimit) {
+          return
+        }
         if (this.sessionDefault.sessionLength > this.maxSessionLength) {
           this.sessionDefault.sessionLength = this.maxSessionLength
         }


### PR DESCRIPTION
Helps to fix https://github.com/RebelCode/rcmod-wp-bookings-ui/issues/41

### Fix description
Added functionality will limit session length field to 23 hours and 59 minutes. Implementation watches for value changes and if session length value is bigger them maximum allowed value for selected time unit (23 for hours), session length value becomes that maximum allowed value.